### PR TITLE
Refactor parse width or height into single function

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -208,6 +208,16 @@ exports.parseMeasurement = function parseMeasurement(val) {
     return exports.parsePercent(val);
 };
 
+exports.parseWidthOrHeight = function parseWidthOrHeight(val) {
+    if (String(val).toLowerCase() === 'auto') {
+        return 'auto';
+    }
+    if (String(val).toLowerCase() === 'inherit') {
+        return 'inherit';
+    }
+    return exports.parseMeasurement(val);
+}
+
 exports.parseUrl = function parseUrl(val) {
     var type = exports.valueType(val);
     if (type === exports.TYPES.NULL_OR_EMPTY_STR) {

--- a/lib/properties/height.js
+++ b/lib/properties/height.js
@@ -1,20 +1,10 @@
 'use strict';
 
-var parseMeasurement = require('../parsers').parseMeasurement;
-
-function parse(v) {
-    if (String(v).toLowerCase() === 'auto') {
-        return 'auto';
-    }
-    if (String(v).toLowerCase() === 'inherit') {
-        return 'inherit';
-    }
-    return parseMeasurement(v);
-}
+var parseWidthOrHeight = require('../parsers').parseWidthOrHeight;
 
 module.exports.definition = {
     set: function (v) {
-        this._setProperty('height', parse(v));
+        this._setProperty('height', parseWidthOrHeight(v));
     },
     get: function () {
         return this.getPropertyValue('height');

--- a/lib/properties/width.js
+++ b/lib/properties/width.js
@@ -1,20 +1,10 @@
 'use strict';
 
-var parseMeasurement = require('../parsers').parseMeasurement;
-
-function parse(v) {
-    if (String(v).toLowerCase() === 'auto') {
-        return 'auto';
-    }
-    if (String(v).toLowerCase() === 'inherit') {
-        return 'inherit';
-    }
-    return parseMeasurement(v);
-}
+var parseWidthOrHeight = require('../parsers').parseWidthOrHeight;
 
 module.exports.definition = {
     set: function (v) {
-        this._setProperty('width', parse(v));
+        this._setProperty('width', parseWidthOrHeight(v));
     },
     get: function () {
         return this.getPropertyValue('width');


### PR DESCRIPTION
Addresses #44 

Otherwise `function parse` is included twice in the output
`properties.js` and the package is unuseable
