### PR TITLE
Add support for numeric values passed to ‘border-spacing’, e.g. ‘border-spacing: 0’.

### DIFF
--- a/lib/properties/borderSpacing.js
+++ b/lib/properties/borderSpacing.js
@@ -10,6 +10,7 @@ var parse = function parse(v) {
     if (v === '' || v === null) {
         return undefined;
     }
+    v = v + '';
     if (v.toLowerCase() === 'inherit') {
         return v;
     }


### PR DESCRIPTION
When providing `0` to `border-spacing`, cssstyle throws a `v.toLowerCase is not a function` error.