### PR TITLE
An alternative fix for PR#47 - Add support for numeric values passed to ‘border-spacing’, e.g. ‘border-spacing: 0’

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CSSStyleDeclaration is a work-a-like to the CSSStyleDeclaration class in Nikita 
 
 Why not just issue a pull request?
 ----
-Well, NV wants to keep CSSOM fast (which I can appreciate) and CSS2Properties aren't required by the standard (though every browser has the interface). So I figured the path of least resistence would be to just modify this one class, publish it as a node module (that requires CSSOM) and then make a pull request of jsdom to use it.
+Well, NV wants to keep CSSOM fast (which I can appreciate) and CSS2Properties aren't required by the standard (though every browser has the interface). So I figured the path of least resistance would be to just modify this one class, publish it as a node module (that requires CSSOM) and then make a pull request of jsdom to use it.
 
 How do I test this code?
 ---

--- a/lib/properties/borderSpacing.js
+++ b/lib/properties/borderSpacing.js
@@ -10,6 +10,9 @@ var parse = function parse(v) {
     if (v === '' || v === null) {
         return undefined;
     }
+    if (typeof v === 'number') {
+        v = String(v)
+    }
     if (v.toLowerCase() === 'inherit') {
         return v;
     }

--- a/lib/properties/borderSpacing.js
+++ b/lib/properties/borderSpacing.js
@@ -10,8 +10,8 @@ var parse = function parse(v) {
     if (v === '' || v === null) {
         return undefined;
     }
-    if (typeof v === 'number') {
-        v = String(v)
+    if (v === 0) {
+        return "0px";
     }
     if (v.toLowerCase() === 'inherit') {
         return v;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "resolve": "~1.1.7"
   },
   "scripts": {
-    "test": "./scripts/run_tests.sh",
+    "test": "node ./scripts/generate_properties.js && nodeunit tests",
     "prepublish": "node ./scripts/generate_properties.js"
   },
   "license": "MIT"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-node ./scripts/generate_properties.js
-nodeunit tests

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -420,5 +420,12 @@ module.exports = {
         style.flexDirection = 'row';
         test.equal(style.cssText, 'flex-direction: row;', 'flex-direction is not column');
         test.done();
+    },
+    'Support non string entries in border-spacing': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(1);
+        style.borderSpacing = 0;
+        test.equal(style.cssText, 'border-spacing: 0;', 'border-spacing is not 0');
+        test.done();
     }
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -425,7 +425,7 @@ module.exports = {
         var style = new cssstyle.CSSStyleDeclaration();
         test.expect(1);
         style.borderSpacing = 0;
-        test.equal(style.cssText, 'border-spacing: 0;', 'border-spacing is not 0');
+        test.equal(style.cssText, 'border-spacing: 0px;', 'border-spacing is not 0');
         test.done();
     }
 };


### PR DESCRIPTION
This fix include a test and follow the approach used in [padding.js](https://github.com/chad3814/CSSStyleDeclaration/blob/master/lib/properties/padding.js)