### PR TITLE
Ensure ex length units are correctly parsed

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -21,7 +21,7 @@ exports.TYPES = {
 // rough regular expressions
 var integerRegEx = /^[\-+]?[0-9]+$/;
 var numberRegEx = /^[\-+]?[0-9]*\.[0-9]+$/;
-var lengthRegEx = /^(0|[\-+]?[0-9]*\.?[0-9]+(in|cm|em|mm|pt|pc|px))$/;
+var lengthRegEx = /^(0|[\-+]?[0-9]*\.?[0-9]+(in|cm|em|mm|pt|pc|px|ex))$/;
 var percentRegEx = /^[\-+]?[0-9]*\.?[0-9]+%$/;
 var urlRegEx = /^url\(\s*([^\)]*)\s*\)$/;
 var stringRegEx = /^(\"[^\"]*\"|\'[^\']*\')$/;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -393,6 +393,16 @@ module.exports = {
         test.equal(style.marginTop, '0px', 'margin-top is not 0px');
         test.done();
     },
+    'Make sure setting ex units to a padding or margin works': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(2);
+        style.padding = '1ex';
+        test.equal(style.cssText, 'padding: 1ex;', 'padding is not 1ex');
+        style.margin = '1em';
+        style.marginTop = '0.5ex'
+        test.equal(style.marginTop, '0.5ex', 'margin-top is not 0.5ex');
+        test.done();
+    },
     'Make sure setting null to background works': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
         test.expect(2);


### PR DESCRIPTION
Per https://www.quirksmode.org/css/units-values/ the 'ex' unit has widespread cross-browser support, and it's even relied on by Gmail in styling its "quoted text" bars to send within emails. However, it was missing from the parser, causing JSDOM to silently drop any style rule that used ex values - not the easiest thing to debug! We've added a quick fix to the regex, as well as unit tests that fail without the changed regex and succeed with it.

Hopefully this can be a quick merge and minor release!