### PR TITLE
Add rem unit to parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "CSSStyleDeclaration",
     "StyleSheet"
   ],
-  "version": "0.2.36",
+  "version": "0.2.37",
   "homepage": "https://github.com/chad3814/CSSStyleDeclaration",
   "maintainers": [
     {
@@ -22,6 +22,9 @@
     },
     {
       "name": "Davide P. Cervone"
+    },
+    {
+      "name": "Forbes Lindesay"
     }
   ],
   "repository": "chad3814/CSSStyleDeclaration",


### PR DESCRIPTION
`rem` is now a valid css unit which should be supported by CSSStyleDeclaration.

See https://developer.mozilla.org/en-US/docs/Web/CSS/length
