### PR TITLE
cross-platform `npm test` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "resolve": "~1.1.7"
   },
   "scripts": {
-    "test": "./scripts/run_tests.sh",
+    "test": "node ./scripts/generate_properties.js && nodeunit tests",
     "prepublish": "node ./scripts/generate_properties.js"
   },
   "license": "MIT"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-node ./scripts/generate_properties.js
-nodeunit tests


### PR DESCRIPTION
The previous `npm test` script executed a `.sh` file
that isn't natively supported by Windows.

Since the actual code inside the `.sh` is pretty small,
it can be completely embedded inside a `npm` script instead,
making it cross-platform and more straight-forward.

_This is a suggestion, if there are specific reasons why this should be in a `.sh` file as it was, disregard this PR._