### PR TITLE
Added more Flex-related styles.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,4 @@
+module.exports.POSITION_AT_SHORTHAND = {
+    first: 0,
+    second: 1
+}

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -488,10 +488,10 @@ exports.shorthandParser = function parse(v, shorthand_for) {
     }
     var parts = getParts(v);
     var valid = true;
-    parts.forEach(function (part) {
+    parts.forEach(function (part, partIndex) {
         var part_valid = false;
         Object.keys(shorthand_for).forEach(function (property) {
-            if (shorthand_for[property].isValid(part)) {
+            if (shorthand_for[property].isValid(part, partIndex)) {
                 part_valid = true;
                 obj[property] = part;
             }

--- a/lib/properties/flex.js
+++ b/lib/properties/flex.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var shorthandParser = require('../parsers').shorthandParser;
+var shorthandSetter = require('../parsers').shorthandSetter;
+var shorthandGetter = require('../parsers').shorthandGetter;
+
+var shorthand_for = {
+    'flex-grow': require('./flexGrow'),
+    'flex-shrink': require('./flexShrink'),
+    'flex-basis': require('./flexBasis'),
+};
+
+module.exports.isValid = function isValid(v) {
+    return shorthandParser(v, shorthand_for) !== undefined;
+};
+
+module.exports.definition = {
+    set: shorthandSetter('flex', shorthand_for),
+    get: shorthandGetter('flex', shorthand_for),
+    enumerable: true,
+    configurable: true
+};

--- a/lib/properties/flex.js
+++ b/lib/properties/flex.js
@@ -10,12 +10,33 @@ var shorthand_for = {
     'flex-basis': require('./flexBasis'),
 };
 
+var myShorthandSetter = shorthandSetter('flex', shorthand_for);
+
 module.exports.isValid = function isValid(v) {
     return shorthandParser(v, shorthand_for) !== undefined;
 };
 
 module.exports.definition = {
-    set: shorthandSetter('flex', shorthand_for),
+    set: function(v) {
+        var normalizedValue = String(v).trim().toLowerCase();
+        
+        if (normalizedValue === 'none') {
+            myShorthandSetter.call(this, '0 0 auto');
+            return;
+        }
+        if (normalizedValue === 'initial') {
+            myShorthandSetter.call(this, '0 1 auto');
+            return;
+        }
+        if (normalizedValue === 'auto') {
+            this.removeProperty('flex-grow');
+            this.removeProperty('flex-shrink');
+            this.setProperty('flex-basis', normalizedValue);
+            return;
+        }
+        
+        myShorthandSetter.call(this, v)
+    },
     get: shorthandGetter('flex', shorthand_for),
     enumerable: true,
     configurable: true

--- a/lib/properties/flex.js
+++ b/lib/properties/flex.js
@@ -1,22 +1,12 @@
 'use strict';
 
-var shorthandParser = require('../parsers').shorthandParser;
-var shorthandSetter = require('../parsers').shorthandSetter;
-var shorthandGetter = require('../parsers').shorthandGetter;
-
-var shorthand_for = {
-    'flex-grow': require('./flexGrow'),
-    'flex-shrink': require('./flexShrink'),
-    'flex-basis': require('./flexBasis'),
-};
-
-module.exports.isValid = function isValid(v) {
-    return shorthandParser(v, shorthand_for) !== undefined;
-};
-
 module.exports.definition = {
-    set: shorthandSetter('flex', shorthand_for),
-    get: shorthandGetter('flex', shorthand_for),
+    set: function (v) {
+        this._setProperty('flex', v);
+    },
+    get: function () {
+        return this.getPropertyValue('flex');
+    },
     enumerable: true,
     configurable: true
 };

--- a/lib/properties/flex.js
+++ b/lib/properties/flex.js
@@ -1,12 +1,22 @@
 'use strict';
 
+var shorthandParser = require('../parsers').shorthandParser;
+var shorthandSetter = require('../parsers').shorthandSetter;
+var shorthandGetter = require('../parsers').shorthandGetter;
+
+var shorthand_for = {
+    'flex-grow': require('./flexGrow'),
+    'flex-shrink': require('./flexShrink'),
+    'flex-basis': require('./flexBasis'),
+};
+
+module.exports.isValid = function isValid(v) {
+    return shorthandParser(v, shorthand_for) !== undefined;
+};
+
 module.exports.definition = {
-    set: function (v) {
-        this._setProperty('flex', v);
-    },
-    get: function () {
-        return this.getPropertyValue('flex');
-    },
+    set: shorthandSetter('flex', shorthand_for),
+    get: shorthandGetter('flex', shorthand_for),
     enumerable: true,
     configurable: true
 };

--- a/lib/properties/flexBasis.js
+++ b/lib/properties/flexBasis.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var parseMeasurement = require('../parsers').parseMeasurement;
+
+function parse(v) {
+    if (String(v).toLowerCase() === 'auto') {
+        return 'auto';
+    }
+    if (String(v).toLowerCase() === 'inherit') {
+        return 'inherit';
+    }
+    return parseMeasurement(v);
+}
+
+module.exports.isValid = function isValid(v) {
+    return parse(v) !== undefined;
+};
+
+module.exports.definition = {
+    set: function (v) {
+        this._setProperty('flex-basis', parse(v));
+    },
+    get: function () {
+        return this.getPropertyValue('flex-basis');
+    },
+    enumerable: true,
+    configurable: true
+};

--- a/lib/properties/flexGrow.js
+++ b/lib/properties/flexGrow.js
@@ -2,6 +2,7 @@
 
 var parseNumber = require('../parsers').parseNumber;
 
+
 module.exports.isValid = function isValid(v) {
     return parseNumber(v) !== undefined;
 };

--- a/lib/properties/flexGrow.js
+++ b/lib/properties/flexGrow.js
@@ -1,10 +1,11 @@
 'use strict';
 
 var parseNumber = require('../parsers').parseNumber;
+var POSITION_AT_SHORTHAND = require('../constants').POSITION_AT_SHORTHAND;
 
 
-module.exports.isValid = function isValid(v) {
-    return parseNumber(v) !== undefined;
+module.exports.isValid = function isValid(v, positionAtFlexShorthand) {
+    return parseNumber(v) !== undefined && positionAtFlexShorthand === POSITION_AT_SHORTHAND.first;
 };
 
 module.exports.definition = {

--- a/lib/properties/flexGrow.js
+++ b/lib/properties/flexGrow.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var parseNumber = require('../parsers').parseNumber;
+
+
+module.exports.isValid = function isValid(v) {
+    return parseNumber(v) !== undefined;
+};
+
+module.exports.definition = {
+    set: function (v) {
+        this._setProperty('flex-grow', parseNumber(v));
+    },
+    get: function () {
+        return this.getPropertyValue('flex-grow');
+    },
+    enumerable: true,
+    configurable: true
+};

--- a/lib/properties/flexGrow.js
+++ b/lib/properties/flexGrow.js
@@ -2,7 +2,6 @@
 
 var parseNumber = require('../parsers').parseNumber;
 
-
 module.exports.isValid = function isValid(v) {
     return parseNumber(v) !== undefined;
 };

--- a/lib/properties/flexShrink.js
+++ b/lib/properties/flexShrink.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var parseNumber = require('../parsers').parseNumber;
+
+module.exports.isValid = function isValid(v) {
+    return parseNumber(v) !== undefined;
+};
+
+module.exports.definition = {
+    set: function (v) {
+        this._setProperty('flex-shrink', parseNumber(v));
+    },
+    get: function () {
+        return this.getPropertyValue('flex-shrink');
+    },
+    enumerable: true,
+    configurable: true
+};

--- a/lib/properties/flexShrink.js
+++ b/lib/properties/flexShrink.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var parseNumber = require('../parsers').parseNumber;
+var POSITION_AT_SHORTHAND = require('../constants').POSITION_AT_SHORTHAND;
 
-module.exports.isValid = function isValid(v) {
-    return parseNumber(v) !== undefined;
+module.exports.isValid = function isValid(v, positionAtFlexShorthand) {
+    return parseNumber(v) !== undefined && positionAtFlexShorthand === POSITION_AT_SHORTHAND.second;
 };
 
 module.exports.definition = {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -446,5 +446,41 @@ module.exports = {
         style.borderSpacing = 0;
         test.equal(style.cssText, 'border-spacing: 0px;', 'border-spacing is not 0');
         test.done();
+    },
+    'Make sure flex-shrink works': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(3);
+        style.setProperty('flex-shrink', 0);
+        test.equal(style.getPropertyValue('flex-shrink'), '0', 'flex-shrink is not 0');
+        style.setProperty('flex-shrink', 1);
+        test.equal(style.getPropertyValue('flex-shrink'), '1', 'flex-shrink is not 1');
+        test.equal(style.cssText, 'flex-shrink: 1;', 'flex-shrink cssText is incorrect');
+        test.done();
+    },
+    'Make sure flex-grow works': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(2);
+        style.setProperty('flex-grow', 2);
+        test.equal(style.getPropertyValue('flex-grow'), '2', 'flex-grow is not 2');
+        test.equal(style.cssText, 'flex-grow: 2;', 'flex-grow cssText is incorrect');
+        test.done();
+    },
+    'Make sure flex-basis works': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(3);
+        style.setProperty('flex-basis', 0);
+        test.equal(style.getPropertyValue('flex-basis'), '0px', 'flex-basis is not 0px');
+        style.setProperty('flex-basis', '250px');
+        test.equal(style.getPropertyValue('flex-basis'), '250px', 'flex-basis is not 250px');
+        test.equal(style.cssText, 'flex-basis: 250px;', 'flex-basis cssText is incorrect');
+        test.done();
+    },
+    'Make sure shorthand flex works': function (test) {
+        var style = new cssstyle.CSSStyleDeclaration();
+        test.expect(2);
+        style.setProperty('flex', '0 1 250px');
+        test.equal(style.getPropertyValue('flex'), '0 1 250px', 'flex is not `0 1 250px`');
+        test.equal(style.cssText, 'flex: 0 1 250px;', '');
+        test.done();
     }
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -477,9 +477,7 @@ module.exports = {
     },
     'Make sure shorthand flex works': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
-        test.expect(3);
-        style.setProperty('flex', '250px');
-        test.equal(style.getPropertyValue('flex'), '250px', 'flex is not `250px`');
+        test.expect(2);
         style.setProperty('flex', '0 1 250px');
         test.equal(style.getPropertyValue('flex'), '0 1 250px', 'flex is not `0 1 250px`');
         test.equal(style.cssText, 'flex: 0 1 250px;', '');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -477,7 +477,9 @@ module.exports = {
     },
     'Make sure shorthand flex works': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
-        test.expect(2);
+        test.expect(3);
+        style.setProperty('flex', '250px');
+        test.equal(style.getPropertyValue('flex'), '250px', 'flex is not `250px`');
         style.setProperty('flex', '0 1 250px');
         test.equal(style.getPropertyValue('flex'), '0 1 250px', 'flex is not `0 1 250px`');
         test.equal(style.cssText, 'flex: 0 1 250px;', '');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -467,20 +467,66 @@ module.exports = {
     },
     'Make sure flex-basis works': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
-        test.expect(3);
+        test.expect(5);
+       
         style.setProperty('flex-basis', 0);
         test.equal(style.getPropertyValue('flex-basis'), '0px', 'flex-basis is not 0px');
+
         style.setProperty('flex-basis', '250px');
         test.equal(style.getPropertyValue('flex-basis'), '250px', 'flex-basis is not 250px');
-        test.equal(style.cssText, 'flex-basis: 250px;', 'flex-basis cssText is incorrect');
+        
+        style.setProperty('flex-basis', '10em');
+        test.equal(style.getPropertyValue('flex-basis'), '10em', 'flex-basis is not 10em');
+        
+        style.setProperty('flex-basis', '30%');
+        test.equal(style.getPropertyValue('flex-basis'), '30%', 'flex-basis is not 30%');
+
+        test.equal(style.cssText, 'flex-basis: 30%;', 'flex-basis cssText is incorrect');
+        
         test.done();
     },
     'Make sure shorthand flex works': function (test) {
         var style = new cssstyle.CSSStyleDeclaration();
-        test.expect(2);
+        test.expect(19);
+                
+        style.setProperty('flex', 'none');
+        test.equal(style.getPropertyValue('flex-grow'), '0', 'flex-grow is not 0 if flex: none;');
+        test.equal(style.getPropertyValue('flex-shrink'), '0', 'flex-shrink is not 0 if flex: none;');
+        test.equal(style.getPropertyValue('flex-basis'), 'auto', 'flex-basis is not `auto` if flex: none;');
+        style.removeProperty('flex');
+        style.removeProperty('flex-basis');
+
+        style.setProperty('flex', 'auto');
+        test.equal(style.getPropertyValue('flex-grow'), '', 'flex-grow is not empty if flex: auto;');
+        test.equal(style.getPropertyValue('flex-shrink'), '', 'flex-shrink is not empty if flex: auto;');
+        test.equal(style.getPropertyValue('flex-basis'), 'auto', 'flex-basis is not `auto` if flex: auto;');
+        style.removeProperty('flex');
+ 
         style.setProperty('flex', '0 1 250px');
-        test.equal(style.getPropertyValue('flex'), '0 1 250px', 'flex is not `0 1 250px`');
-        test.equal(style.cssText, 'flex: 0 1 250px;', '');
+        test.equal(style.getPropertyValue('flex'), '0 1 250px', 'flex value is not `0 1 250px`');
+        test.equal(style.getPropertyValue('flex-grow'), '0', 'flex-grow is not 0');
+        test.equal(style.getPropertyValue('flex-shrink'), '1', 'flex-shrink is not 1');
+        test.equal(style.getPropertyValue('flex-basis'), '250px', 'flex-basis is not 250px');
+        style.removeProperty('flex');
+
+        style.setProperty('flex', '2');
+        test.equal(style.getPropertyValue('flex-grow'), '2', 'flex-grow is not 2');
+        test.equal(style.getPropertyValue('flex-shrink'), '', 'flex-shrink is not empty');
+        test.equal(style.getPropertyValue('flex-basis'), '', 'flex-basis is not empty');
+        style.removeProperty('flex');
+
+        style.setProperty('flex', '20%');
+        test.equal(style.getPropertyValue('flex-grow'), '', 'flex-grow is not empty');
+        test.equal(style.getPropertyValue('flex-shrink'), '', 'flex-shrink is not empty');
+        test.equal(style.getPropertyValue('flex-basis'), '20%', 'flex-basis is not 20%');
+        style.removeProperty('flex');
+
+        style.setProperty('flex', '2 2');
+        test.equal(style.getPropertyValue('flex-grow'), '2', 'flex-grow is not 2');
+        test.equal(style.getPropertyValue('flex-shrink'), '2', 'flex-shrink is not 2');
+        test.equal(style.getPropertyValue('flex-basis'), '', 'flex-basis is not empty');
+        style.removeProperty('flex');
+        
         test.done();
     }
 };


### PR DESCRIPTION
Hello there! 
First of all, thank you for awesome work!

By this PR I'm adding some more flex styles:
flex-grow, flex-shrink, flex-basis and flex shorthand.

There is nothing special in this changes, but I'd like to clearify one moment. 
When I added flex shorthand and write tests on it, none of them was 'green'. It turns out, that setting flex shorthand value, for example, `0 1 250px` would give output `1 1 250px`. Flex-grow is being reassigned by flex-shrink value, because it is absolutly valid for it and their type and possible values are identical. 
To resolve this confusion I decided to pass shorhand part's index as second parameter in subprop `isValid` function while runnig shorthandParser. Now it works fine. Tests prove it.

Nonetheless, if you'll see this solution as not clear enough, I'll gladly fix or rewrite this according to your advice :)

Hope it helps somehow. 
Best regards 