### PR TITLE
Change the CI command to test-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ notifications:
 node_js:
   - "node"
 script:
-  - npm test
+  - npm run test-ci

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,7 +1,7 @@
 'use strict';
 var cssstyle = require('../lib/CSSStyleDeclaration');
 
-var { camelToDashed, dashedToCamelCase } = require('../lib/parsers');
+var { dashedToCamelCase } = require('../lib/parsers');
 
 var dashedProperties = [
   ...require('../lib/allProperties'),


### PR DESCRIPTION
The test command deliberately doesn't include linting (it can be very annoying, especially when prototyping). However, we want CI to lint, so `test-ci` is more comprehensive.