### PR TITLE
Test node versions 6, 8, 10, and 11 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
 notifications:
   email: true
 node_js:
-  - "node"
+  - 6
+  - 8
+  - 10
+  - 11
+
 script:
   - npm run test-ci


### PR DESCRIPTION
v1.2.0 broke some apps running in Node 6 due to use of dangling comma. I would like to prevent that from happening again for future updates.