### PR TITLE
fix: Add missing valid color refs 'transparent' and 'currentcolor'

### DIFF
--- a/lib/named_colors.json
+++ b/lib/named_colors.json
@@ -146,5 +146,7 @@
   "white",
   "whitesmoke",
   "yellow",
-  "yellowgreen"
+  "yellowgreen",
+  "transparent",
+  "currentcolor"
 ]

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -215,7 +215,7 @@ module.exports = {
   },
   'Test colors': function(test) {
     var style = new cssstyle.CSSStyleDeclaration();
-    test.expect(7);
+    test.expect(9);
     style.color = 'rgba(0,0,0,0)';
     test.ok('rgba(0, 0, 0, 0)' === style.color, 'color is not rgba(0, 0, 0, 0)');
     style.color = 'rgba(5%, 10%, 20%, 0.4)';
@@ -233,6 +233,10 @@ module.exports = {
     test.ok('hsl(0, 1%, 2%)' === style.color, 'color is not hsl(0, 1%, 2%) ' + style.color);
     style.color = 'rebeccapurple';
     test.ok('rebeccapurple' === style.color, 'color is not rebeccapurple ' + style.color);
+    style.color = 'transparent';
+    test.ok('transparent' === style.color, 'color is not transparent ' + style.color);
+    style.color = 'currentcolor';
+    test.ok('currentcolor' === style.color, 'color is not currentcolor ' + style.color);
     test.done();
   },
   'Test short hand properties with embedded spaces': function(test) {


### PR DESCRIPTION
Currently setting an element's color style with `transparent` or `currentcolor`, both of which are valid, returns an empty string:
```js
var isValidColor = (colour) => {
  var element = document.createElement('div');
  element.style.color = colour;
  return element.style.color;
};

isValidColor('red'); // 'red'
isValidColor('#f00'); // 'rgb(255, 0, 0)'
isValidColor('rebeccapurple'); // 'rebeccapurple'
isValidColor('transparent'); // ''
isValidColor('currentcolor'); // ''
```

Whereas in Chrome v72: 
```js
var isValidColor = (colour) => {
  var element = document.createElement('div');
  element.style.color = colour;
  return element.style.color;
};

isValidColor('red'); // 'red'
isValidColor('#f00'); // 'rgb(255, 0, 0)'
isValidColor('rebeccapurple'); // 'rebeccapurple'
isValidColor('transparent'); // 'transparent'
isValidColor('currentcolor'); // 'currentcolor'
```