### PR TITLE
numberRegEx should match whole numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - 6
   - 8
   - 10
-  - 11
+  - 12
 
 script:
   - npm run test-ci

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -21,7 +21,7 @@ exports.TYPES = {
 
 // rough regular expressions
 var integerRegEx = /^[-+]?[0-9]+$/;
-var numberRegEx = /^[-+]?[0-9]*\.[0-9]+$/;
+var numberRegEx = /^[-+]?[0-9]*\.?[0-9]+$/;
 var lengthRegEx = /^(0|[-+]?[0-9]*\.?[0-9]+(in|cm|em|mm|pt|pc|px|ex|rem|vh|vw))$/;
 var percentRegEx = /^[-+]?[0-9]*\.?[0-9]+%$/;
 var urlRegEx = /^url\(\s*([^)]*)\s*\)$/;


### PR DESCRIPTION
The existing regex requires a decimal. This matches `1.0`, but not `1`, making `rgba(1, 1, 1, 1)` invalid when it should be considered valid.

Closes #92 